### PR TITLE
Add auto-creation of helper objects for unresolved bones

### DIFF
--- a/Editor/Resources/USS/PBRemap.uss
+++ b/Editor/Resources/USS/PBRemap.uss
@@ -203,6 +203,16 @@
     color: var(--unity-colors-default-text);
 }
 
+.preview-bone-auto-creatable {
+    color: rgb(220, 180, 50);
+    font-size: 11px;
+    -unity-font-definition: resource('Font/Noto_Sans_JP/static/NotoSansJP-Bold SDF');
+}
+
+.preview-bone-auto-creatable > Label {
+    color: rgb(220, 180, 50);
+}
+
 .preview-bone-unresolved {
     color: rgb(220, 80, 80);
     font-size: 11px;

--- a/Editor/Resources/USS/PBRemap.uss
+++ b/Editor/Resources/USS/PBRemap.uss
@@ -36,18 +36,75 @@
 }
 
 .pbremap-resolution-summary {
-    font-size: 11px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
     padding: 2px 4px;
     margin-top: 2px;
 }
 
-.pbremap-resolution-resolved {
+.pbremap-resolution-header {
+    font-size: 11px;
+    color: rgb(200, 200, 200);
+    margin-right: 6px;
+    -unity-text-align: middle-left;
+}
+
+.pbremap-resolution-chip {
+    flex-direction: row;
+    align-items: center;
+    margin-right: 6px;
+    padding: 1px 6px 1px 4px;
+    border-radius: 8px;
+}
+
+.pbremap-resolution-chip-resolved {
+    background-color: rgba(100, 200, 100, 0.15);
+}
+
+.pbremap-resolution-chip-auto-creatable {
+    background-color: rgba(220, 180, 50, 0.15);
+}
+
+.pbremap-resolution-chip-unresolved {
+    background-color: rgba(220, 80, 80, 0.15);
+}
+
+.pbremap-resolution-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+    margin-right: 4px;
+    flex-shrink: 0;
+}
+
+.pbremap-resolution-dot-resolved {
+    background-color: rgb(100, 200, 100);
+}
+
+.pbremap-resolution-dot-auto-creatable {
+    background-color: rgb(220, 180, 50);
+}
+
+.pbremap-resolution-dot-unresolved {
+    background-color: rgb(220, 80, 80);
+}
+
+.pbremap-resolution-chip-label {
+    font-size: 11px;
+    -unity-text-align: middle-left;
+}
+
+.pbremap-resolution-chip-label-resolved {
     color: rgb(100, 200, 100);
 }
 
-.pbremap-resolution-unresolved {
+.pbremap-resolution-chip-label-auto-creatable {
     color: rgb(220, 180, 50);
-    -unity-font-style: bold;
+}
+
+.pbremap-resolution-chip-label-unresolved {
+    color: rgb(220, 80, 80);
 }
 
 .pbremap-execute-button {
@@ -133,6 +190,50 @@
     margin-bottom: 4px;
     border-bottom-width: 1px;
     border-bottom-color: rgba(85, 85, 85, 0.5);
+}
+
+.preview-filter-bar {
+    flex-direction: row;
+    padding: 2px 4px;
+    margin-bottom: 2px;
+    border-bottom-width: 1px;
+    border-bottom-color: rgba(85, 85, 85, 0.5);
+}
+
+.preview-filter-toggle {
+    flex-direction: row;
+    align-items: center;
+    margin-right: 4px;
+    padding: 2px 8px 2px 4px;
+    border-radius: 10px;
+    border-width: 1px;
+    cursor: link;
+}
+
+.preview-filter-toggle:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.preview-filter-toggle-active {
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+.preview-filter-toggle-inactive {
+    border-color: rgba(255, 255, 255, 0.06);
+    opacity: 0.5;
+}
+
+.preview-filter-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+    margin-right: 4px;
+    flex-shrink: 0;
+}
+
+.preview-filter-label {
+    font-size: 11px;
+    -unity-text-align: middle-left;
 }
 
 .preview-bone-item {

--- a/Editor/Resources/USS/PBRemapOverlay.uss
+++ b/Editor/Resources/USS/PBRemapOverlay.uss
@@ -1,15 +1,86 @@
 .overlay-panel-root {
-    min-width: 200px;
+    min-width: 220px;
     padding: 4px;
 }
 
-.overlay-summary-label {
-    -unity-font-style: bold;
-    font-size: 12px;
+.overlay-summary-container {
     padding: 2px 4px;
-    margin-bottom: 4px;
+    margin-bottom: 2px;
     border-bottom-width: 1px;
     border-bottom-color: rgba(85, 85, 85, 0.5);
+}
+
+.overlay-summary-header {
+    -unity-font-style: bold;
+    font-size: 12px;
+    margin-bottom: 2px;
+}
+
+.overlay-chip-row {
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-bottom: 2px;
+}
+
+.overlay-summary-chip {
+    flex-direction: row;
+    align-items: center;
+    margin-right: 6px;
+    padding: 1px 5px 1px 3px;
+    border-radius: 7px;
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.overlay-chip-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 4px;
+    margin-right: 3px;
+    flex-shrink: 0;
+}
+
+.overlay-chip-text {
+    font-size: 11px;
+    -unity-text-align: middle-left;
+}
+
+.overlay-filter-bar {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 2px 4px;
+    margin-bottom: 2px;
+    border-bottom-width: 1px;
+    border-bottom-color: rgba(85, 85, 85, 0.5);
+}
+
+.overlay-filter-label {
+    font-size: 10px;
+    color: rgb(160, 160, 160);
+    margin-right: 4px;
+    -unity-text-align: middle-left;
+}
+
+.overlay-filter-chip {
+    flex-direction: row;
+    align-items: center;
+    margin-right: 3px;
+    padding: 1px 6px 1px 3px;
+    border-radius: 8px;
+    border-width: 1px;
+    cursor: link;
+}
+
+.overlay-filter-chip:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.overlay-filter-chip-active {
+    background-color: rgba(255, 255, 255, 0.03);
+}
+
+.overlay-filter-chip-inactive {
+    opacity: 0.5;
 }
 
 .overlay-toggle-row {

--- a/Editor/Resources/UXML/PBRemap.uxml
+++ b/Editor/Resources/UXML/PBRemap.uxml
@@ -17,7 +17,7 @@
     <!-- コンポーネント一覧セクション -->
     <ui:Foldout name="components-foldout" text="移植対象コンポーネント" value="true" class="pbremap-section">
         <ui:Label name="components-summary" text="" class="pbremap-components-summary" />
-        <ui:Label name="resolution-summary" text="" class="pbremap-resolution-summary" style="display: none;" />
+        <ui:VisualElement name="resolution-summary" class="pbremap-resolution-summary" style="display: none;" />
     </ui:Foldout>
 
     <!-- パスリマップルール -->

--- a/Editor/Scripts/PBRemap/Core/BoneMapper.cs
+++ b/Editor/Scripts/PBRemap/Core/BoneMapper.cs
@@ -192,6 +192,53 @@ namespace colloid.PBReplacer
         }
 
         /// <summary>
+        /// アバター配下の全SkinnedMeshRendererからバインド済みボーンのセットを構築する。
+        /// </summary>
+        /// <param name="avatarRoot">アバターのルートGameObject</param>
+        /// <returns>メッシュにバインドされたTransformのセット</returns>
+        public static HashSet<Transform> CollectSkinnedBones(GameObject avatarRoot)
+        {
+            var skinnedBones = new HashSet<Transform>();
+            if (avatarRoot == null)
+                return skinnedBones;
+
+            foreach (var smr in avatarRoot.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+            {
+                if (smr.bones == null) continue;
+                foreach (var bone in smr.bones)
+                {
+                    if (bone != null)
+                        skinnedBones.Add(bone);
+                }
+            }
+            return skinnedBones;
+        }
+
+        /// <summary>
+        /// ボーン自身またはその子孫がメッシュにバインドされているか判定する。
+        /// バインドされていればスケルトンの一部であり、ヘルパーオブジェクトではない。
+        /// </summary>
+        /// <param name="bone">判定対象のボーン</param>
+        /// <param name="skinnedBones">CollectSkinnedBonesで構築したセット</param>
+        /// <returns>スケルトンの一部ならtrue</returns>
+        public static bool IsSkeletonBone(Transform bone, HashSet<Transform> skinnedBones)
+        {
+            if (bone == null || skinnedBones == null || skinnedBones.Count == 0)
+                return false;
+
+            if (skinnedBones.Contains(bone))
+                return true;
+
+            // 子孫にバインド済みボーンがあるかチェック
+            foreach (Transform child in bone.GetComponentsInChildren<Transform>(true))
+            {
+                if (child != bone && skinnedBones.Contains(child))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
         /// リマップルールを考慮してソースボーンをデスティネーションボーンに解決する。
         /// 解決戦略（優先度順）: 完全一致 → リマップ後パスマッチ → リマップ後名前マッチ。
         /// </summary>

--- a/Editor/Scripts/PBRemap/Editor/PBRemapEditor.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapEditor.cs
@@ -337,20 +337,33 @@ namespace colloid.PBReplacer
 
             _resolutionSummary.style.display = DisplayStyle.Flex;
 
-            if (preview.UnresolvedBones == 0)
+            int autoCreatable = preview.AutoCreatableBones;
+            int trueUnresolved = preview.UnresolvedBones - autoCreatable;
+
+            if (trueUnresolved > 0)
             {
-                _resolutionSummary.text = $"ボーン解決: {preview.ResolvedBones}/{total} 全て解決済み";
+                string text = $"ボーン解決: {preview.ResolvedBones}/{total} ({trueUnresolved} 未解決)";
+                if (autoCreatable > 0)
+                    text += $" (作成予定: {autoCreatable})";
+                _resolutionSummary.text = text;
+                _resolutionSummary.RemoveFromClassList("pbremap-resolution-resolved");
+                _resolutionSummary.AddToClassList("pbremap-resolution-unresolved");
+                Highlighter.Highlight("Inspector", "プレビュー", HighlightSearchMode.Auto);
+            }
+            else if (autoCreatable > 0)
+            {
+                _resolutionSummary.text =
+                    $"ボーン解決: {preview.ResolvedBones}/{total} (作成予定: {autoCreatable})";
                 _resolutionSummary.RemoveFromClassList("pbremap-resolution-unresolved");
                 _resolutionSummary.AddToClassList("pbremap-resolution-resolved");
                 Highlighter.Stop();
             }
             else
             {
-                _resolutionSummary.text =
-                    $"ボーン解決: {preview.ResolvedBones}/{total} ({preview.UnresolvedBones} 未解決)";
-                _resolutionSummary.RemoveFromClassList("pbremap-resolution-resolved");
-                _resolutionSummary.AddToClassList("pbremap-resolution-unresolved");
-                Highlighter.Highlight("Inspector", "プレビュー", HighlightSearchMode.Auto);
+                _resolutionSummary.text = $"ボーン解決: {preview.ResolvedBones}/{total} 全て解決済み";
+                _resolutionSummary.RemoveFromClassList("pbremap-resolution-unresolved");
+                _resolutionSummary.AddToClassList("pbremap-resolution-resolved");
+                Highlighter.Stop();
             }
         }
 

--- a/Editor/Scripts/PBRemap/Editor/PBRemapEditor.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapEditor.cs
@@ -816,6 +816,9 @@ namespace colloid.PBReplacer
                         $"リマップ済みコンポーネント: {success.RemappedComponentCount}\n" +
                         $"リマップ済み参照: {success.RemappedReferenceCount}";
 
+                    if (success.AutoCreatedObjectCount > 0)
+                        message += $"\n自動作成オブジェクト: {success.AutoCreatedObjectCount}";
+
                     if (success.UnresolvedReferenceCount > 0)
                         message += $"\n未解決参照: {success.UnresolvedReferenceCount}";
 
@@ -825,7 +828,10 @@ namespace colloid.PBReplacer
 
                     EditorUtility.DisplayDialog("移植完了", message, "OK");
 
-                    _statusBox.text = $"移植完了: {success.RemappedReferenceCount} 参照をリマップ";
+                    _statusBox.text = $"移植完了: {success.RemappedReferenceCount} 参照をリマップ" +
+                        (success.AutoCreatedObjectCount > 0
+                            ? $", {success.AutoCreatedObjectCount} オブジェクトを自動作成"
+                            : "");
                     _statusBox.messageType = success.UnresolvedReferenceCount > 0
                         ? HelpBoxMessageType.Warning
                         : HelpBoxMessageType.Info;

--- a/Editor/Scripts/PBRemap/Editor/PBRemapPreview.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapPreview.cs
@@ -87,11 +87,12 @@ namespace colloid.PBReplacer
                 GeneratePrefabModePreview(preview, definition, detection);
             }
 
-            // 未解決ボーンの警告
-            if (preview.UnresolvedBones > 0)
+            // 未解決ボーンの警告（autoCreatableは除外）
+            int trueUnresolved = preview.UnresolvedBones - preview.AutoCreatableBones;
+            if (trueUnresolved > 0)
             {
                 preview.Warnings.Add(
-                    $"{preview.UnresolvedBones} 個のボーンが解決できませんでした。" +
+                    $"{trueUnresolved} 個のボーンが解決できませんでした。" +
                     "パスリマップルールの追加を検討してください。");
             }
 

--- a/Editor/Scripts/PBRemap/Editor/PBRemapPreviewWindow.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapPreviewWindow.cs
@@ -90,11 +90,14 @@ namespace colloid.PBReplacer
 			}
 
 			int totalBones = _preview.ResolvedBones + _preview.UnresolvedBones;
-			_summaryLabel.text =
+			var summaryText =
 				$"PB: {_preview.TotalPhysBones}  PBC: {_preview.TotalPhysBoneColliders}  " +
 				$"Constraint: {_preview.TotalConstraints}  Contact: {_preview.TotalContacts}\n" +
-				$"ボーン解決: {_preview.ResolvedBones}/{totalBones}  |  " +
-				$"スケール: {_preview.CalculatedScaleFactor:F3}";
+				$"ボーン解決: {_preview.ResolvedBones}/{totalBones}";
+			if (_preview.AutoCreatableBones > 0)
+				summaryText += $"  作成予定: {_preview.AutoCreatableBones}";
+			summaryText += $"  |  スケール: {_preview.CalculatedScaleFactor:F3}";
+			_summaryLabel.text = summaryText;
 
 			_boneScrollView.Clear();
 			foreach (var mapping in _preview.BoneMappings)
@@ -130,6 +133,18 @@ namespace colloid.PBReplacer
 					destLabel.RegisterCallback<ClickEvent>(evt => PingBone(destPath));
 
 					// 解決済み行: actionsは空スペーサー
+				}
+				else if (mapping.autoCreatable)
+				{
+					// 自動作成予定: 親ボーンは解決済み、子オブジェクトを作成予定
+					destLabel.text = mapping.autoCreateDestPath + " (作成予定)";
+					destLabel.tooltip = "親ボーンが解決済みのため、子オブジェクトを自動作成できます"
+						+ $"\n作成先: {mapping.autoCreateDestPath}";
+					row.AddToClassList("preview-bone-auto-creatable");
+
+					// destラベルクリック → 親ボーンの解決先をPing
+					string sourcePath = mapping.sourceBonePath;
+					destLabel.RegisterCallback<ClickEvent>(evt => PingNearestResolvedBone(sourcePath));
 				}
 				else
 				{

--- a/Editor/Scripts/PBRemap/Editor/PBRemapSceneOverlay.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapSceneOverlay.cs
@@ -106,10 +106,13 @@ namespace colloid.PBReplacer
 				return;
 			}
 
-			int unresolved = state.TotalCount - state.ResolvedCount;
+			int autoCreatable = state.AutoCreatableCount;
+			int unresolved = state.TotalCount - state.ResolvedCount - autoCreatable;
 			_summaryLabel.text =
 				$"\u89e3\u6c7a\u6e08\u307f: {state.ResolvedCount}/{state.TotalCount}";
 
+			if (autoCreatable > 0)
+				_summaryLabel.text += $"  (\u4f5c\u6210\u4e88\u5b9a: {autoCreatable})";
 			if (unresolved > 0)
 				_summaryLabel.text += $"  (\u672a\u89e3\u6c7a: {unresolved})";
 		}

--- a/Editor/Scripts/PBRemap/Editor/PBRemapSceneOverlay.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapSceneOverlay.cs
@@ -21,10 +21,13 @@ namespace colloid.PBReplacer
 		private Toggle _showLinesToggle;
 		private Toggle _showLabelsToggle;
 
-		// フィルターチップ（定期更新でカウントを反映するため保持）
+		// キャッシュ（定期更新で変更検知に使用）
 		private int _cachedResolved;
 		private int _cachedAutoCreatable;
 		private int _cachedUnresolved;
+		private bool _cachedShowResolved;
+		private bool _cachedShowAutoCreatable;
+		private bool _cachedShowUnresolved;
 
 		// 色定数
 		private static readonly Color ResolvedColor = new Color(0.39f, 0.78f, 0.39f);
@@ -116,16 +119,22 @@ namespace colloid.PBReplacer
 			int autoCreatable = state.AutoCreatableCount;
 			int unresolved = state.TotalCount - resolved - autoCreatable;
 
-			// カウントが変わっていなければ再構築不要
+			// カウントもフィルター状態も変わっていなければ再構築不要
 			if (resolved == _cachedResolved
 				&& autoCreatable == _cachedAutoCreatable
 				&& unresolved == _cachedUnresolved
+				&& state.ShowResolved == _cachedShowResolved
+				&& state.ShowAutoCreatable == _cachedShowAutoCreatable
+				&& state.ShowUnresolved == _cachedShowUnresolved
 				&& _summaryContainer.childCount > 0)
 				return;
 
 			_cachedResolved = resolved;
 			_cachedAutoCreatable = autoCreatable;
 			_cachedUnresolved = unresolved;
+			_cachedShowResolved = state.ShowResolved;
+			_cachedShowAutoCreatable = state.ShowAutoCreatable;
+			_cachedShowUnresolved = state.ShowUnresolved;
 
 			// サマリー再構築
 			_summaryContainer.Clear();

--- a/Editor/Scripts/PBRemap/Editor/PBRemapSceneOverlay.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapSceneOverlay.cs
@@ -16,10 +16,20 @@ namespace colloid.PBReplacer
 
 		public bool visible => PBRemapScenePreviewState.Instance.IsActive;
 
-		private Label _summaryLabel;
+		private VisualElement _summaryContainer;
+		private VisualElement _filterBar;
 		private Toggle _showLinesToggle;
 		private Toggle _showLabelsToggle;
-		private Toggle _showUnresolvedOnlyToggle;
+
+		// フィルターチップ（定期更新でカウントを反映するため保持）
+		private int _cachedResolved;
+		private int _cachedAutoCreatable;
+		private int _cachedUnresolved;
+
+		// 色定数
+		private static readonly Color ResolvedColor = new Color(0.39f, 0.78f, 0.39f);
+		private static readonly Color AutoCreatableColor = new Color(0.86f, 0.71f, 0.20f);
+		private static readonly Color UnresolvedColor = new Color(0.86f, 0.31f, 0.31f);
 
 		public override void OnCreated()
 		{
@@ -40,14 +50,19 @@ namespace colloid.PBReplacer
 			if (styleSheet != null)
 				root.styleSheets.Add(styleSheet);
 
-			// サマリー
-			_summaryLabel = new Label();
-			_summaryLabel.AddToClassList("overlay-summary-label");
-			root.Add(_summaryLabel);
+			// サマリー（カラーチップ表示）
+			_summaryContainer = new VisualElement();
+			_summaryContainer.AddToClassList("overlay-summary-container");
+			root.Add(_summaryContainer);
 
-			// トグル群
+			// フィルターバー（3状態トグル）
+			_filterBar = new VisualElement();
+			_filterBar.AddToClassList("overlay-filter-bar");
+			root.Add(_filterBar);
+
+			// 表示設定トグル
 			_showLinesToggle = CreateToggle(
-				"\u63a5\u7d9a\u30e9\u30a4\u30f3\u3092\u8868\u793a",
+				"接続ラインを表示",
 				PBRemapScenePreviewState.Instance.ShowConnectionLines,
 				evt =>
 				{
@@ -57,7 +72,7 @@ namespace colloid.PBReplacer
 			root.Add(_showLinesToggle);
 
 			_showLabelsToggle = CreateToggle(
-				"\u30dc\u30fc\u30f3\u540d\u30e9\u30d9\u30eb\u3092\u8868\u793a",
+				"ボーン名ラベルを表示",
 				PBRemapScenePreviewState.Instance.ShowBoneLabels,
 				evt =>
 				{
@@ -66,20 +81,10 @@ namespace colloid.PBReplacer
 				});
 			root.Add(_showLabelsToggle);
 
-			_showUnresolvedOnlyToggle = CreateToggle(
-				"\u672a\u89e3\u6c7a\u306e\u307f\u8868\u793a",
-				PBRemapScenePreviewState.Instance.ShowUnresolvedOnly,
-				evt =>
-				{
-					PBRemapScenePreviewState.Instance.ShowUnresolvedOnly = evt.newValue;
-					SceneView.RepaintAll();
-				});
-			root.Add(_showUnresolvedOnlyToggle);
+			UpdatePanel();
 
-			UpdateSummary();
-
-			// 定期的にサマリーを更新
-			root.schedule.Execute(UpdateSummary).Every(500);
+			// 定期的にパネルを更新
+			root.schedule.Execute(UpdatePanel).Every(500);
 
 			return root;
 		}
@@ -94,27 +99,115 @@ namespace colloid.PBReplacer
 			return toggle;
 		}
 
-		private void UpdateSummary()
+		private void UpdatePanel()
 		{
-			if (_summaryLabel == null)
+			if (_summaryContainer == null || _filterBar == null)
 				return;
 
 			var state = PBRemapScenePreviewState.Instance;
 			if (!state.IsActive)
 			{
-				_summaryLabel.text = "";
+				_summaryContainer.Clear();
+				_filterBar.Clear();
 				return;
 			}
 
+			int resolved = state.ResolvedCount;
 			int autoCreatable = state.AutoCreatableCount;
-			int unresolved = state.TotalCount - state.ResolvedCount - autoCreatable;
-			_summaryLabel.text =
-				$"\u89e3\u6c7a\u6e08\u307f: {state.ResolvedCount}/{state.TotalCount}";
+			int unresolved = state.TotalCount - resolved - autoCreatable;
 
+			// カウントが変わっていなければ再構築不要
+			if (resolved == _cachedResolved
+				&& autoCreatable == _cachedAutoCreatable
+				&& unresolved == _cachedUnresolved
+				&& _summaryContainer.childCount > 0)
+				return;
+
+			_cachedResolved = resolved;
+			_cachedAutoCreatable = autoCreatable;
+			_cachedUnresolved = unresolved;
+
+			// サマリー再構築
+			_summaryContainer.Clear();
+			var header = new Label($"ボーン解決: {resolved}/{state.TotalCount}");
+			header.AddToClassList("overlay-summary-header");
+			_summaryContainer.Add(header);
+
+			var chipRow = new VisualElement();
+			chipRow.AddToClassList("overlay-chip-row");
+			if (resolved > 0)
+				chipRow.Add(CreateSummaryChip(resolved, "解決", ResolvedColor));
 			if (autoCreatable > 0)
-				_summaryLabel.text += $"  (\u4f5c\u6210\u4e88\u5b9a: {autoCreatable})";
+				chipRow.Add(CreateSummaryChip(autoCreatable, "作成予定", AutoCreatableColor));
 			if (unresolved > 0)
-				_summaryLabel.text += $"  (\u672a\u89e3\u6c7a: {unresolved})";
+				chipRow.Add(CreateSummaryChip(unresolved, "未解決", UnresolvedColor));
+			_summaryContainer.Add(chipRow);
+
+			// フィルターバー再構築
+			_filterBar.Clear();
+			var filterLabel = new Label("表示:");
+			filterLabel.AddToClassList("overlay-filter-label");
+			_filterBar.Add(filterLabel);
+
+			_filterBar.Add(CreateFilterChip(
+				resolved, "解決済み", ResolvedColor, state.ShowResolved,
+				v => { state.ShowResolved = v; _cachedResolved = -1; UpdatePanel(); SceneView.RepaintAll(); }));
+			_filterBar.Add(CreateFilterChip(
+				autoCreatable, "作成予定", AutoCreatableColor, state.ShowAutoCreatable,
+				v => { state.ShowAutoCreatable = v; _cachedAutoCreatable = -1; UpdatePanel(); SceneView.RepaintAll(); }));
+			_filterBar.Add(CreateFilterChip(
+				unresolved, "未解決", UnresolvedColor, state.ShowUnresolved,
+				v => { state.ShowUnresolved = v; _cachedUnresolved = -1; UpdatePanel(); SceneView.RepaintAll(); }));
+		}
+
+		private static VisualElement CreateSummaryChip(int count, string label, Color color)
+		{
+			var chip = new VisualElement();
+			chip.AddToClassList("overlay-summary-chip");
+
+			var dot = new VisualElement();
+			dot.AddToClassList("overlay-chip-dot");
+			dot.style.backgroundColor = color;
+			chip.Add(dot);
+
+			var text = new Label($"{count} {label}");
+			text.AddToClassList("overlay-chip-text");
+			text.style.color = color;
+			chip.Add(text);
+
+			return chip;
+		}
+
+		private static VisualElement CreateFilterChip(
+			int count, string label, Color color, bool active, System.Action<bool> onToggle)
+		{
+			var chip = new VisualElement();
+			chip.AddToClassList("overlay-filter-chip");
+			chip.AddToClassList(active ? "overlay-filter-chip-active" : "overlay-filter-chip-inactive");
+
+			var borderColor = active ? color : new Color(1, 1, 1, 0.08f);
+			chip.style.borderTopColor = borderColor;
+			chip.style.borderBottomColor = borderColor;
+			chip.style.borderLeftColor = borderColor;
+			chip.style.borderRightColor = borderColor;
+
+			var dot = new VisualElement();
+			dot.AddToClassList("overlay-chip-dot");
+			dot.style.backgroundColor = active
+				? (StyleColor)color
+				: new StyleColor(new Color(color.r, color.g, color.b, 0.3f));
+			chip.Add(dot);
+
+			var text = new Label($"{count} {label}");
+			text.AddToClassList("overlay-chip-text");
+			text.style.color = active
+				? (StyleColor)color
+				: new StyleColor(new Color(0.6f, 0.6f, 0.6f));
+			chip.Add(text);
+
+			chip.RegisterCallback<ClickEvent>(evt => onToggle(!active));
+
+			return chip;
 		}
 	}
 }

--- a/Editor/Scripts/PBRemap/Editor/PBRemapScenePreviewState.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapScenePreviewState.cs
@@ -30,6 +30,7 @@ namespace colloid.PBReplacer
 
 		// サマリー
 		public int ResolvedCount { get; private set; }
+		public int AutoCreatableCount { get; private set; }
 		public int TotalCount { get; private set; }
 
 		/// <summary>
@@ -54,6 +55,7 @@ namespace colloid.PBReplacer
 			Detection = null;
 			VisualMappings.Clear();
 			ResolvedCount = 0;
+			AutoCreatableCount = 0;
 			TotalCount = 0;
 			SceneView.RepaintAll();
 		}
@@ -66,6 +68,7 @@ namespace colloid.PBReplacer
 		{
 			VisualMappings.Clear();
 			ResolvedCount = 0;
+			AutoCreatableCount = 0;
 			TotalCount = 0;
 
 			if (PreviewData == null || Detection == null)
@@ -100,6 +103,18 @@ namespace colloid.PBReplacer
 						BoneMapper.FindBoneByRelativePath(mapping.destinationBonePath, destArmature);
 					ResolvedCount++;
 				}
+				else if (mapping.autoCreatable && !string.IsNullOrEmpty(mapping.autoCreateDestPath))
+				{
+					// autoCreateDestPathの親パスからTransformを取得
+					int lastSlash = mapping.autoCreateDestPath.LastIndexOf('/');
+					string parentDestPath = lastSlash >= 0
+						? mapping.autoCreateDestPath.Substring(0, lastSlash)
+						: "";
+					visual.AutoCreateParentTransform =
+						BoneMapper.FindBoneByRelativePath(parentDestPath, destArmature);
+					visual.AutoCreatable = true;
+					AutoCreatableCount++;
+				}
 
 				VisualMappings.Add(visual);
 			}
@@ -119,5 +134,7 @@ namespace colloid.PBReplacer
 		public string ErrorMessage;
 		public Transform SourceTransform;
 		public Transform DestTransform;
+		public bool AutoCreatable;
+		public Transform AutoCreateParentTransform;
 	}
 }

--- a/Editor/Scripts/PBRemap/Editor/PBRemapScenePreviewState.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapScenePreviewState.cs
@@ -26,7 +26,9 @@ namespace colloid.PBReplacer
 		// 表示設定
 		public bool ShowConnectionLines { get; set; } = true;
 		public bool ShowBoneLabels { get; set; } = false;
-		public bool ShowUnresolvedOnly { get; set; } = false;
+		public bool ShowResolved { get; set; } = true;
+		public bool ShowAutoCreatable { get; set; } = true;
+		public bool ShowUnresolved { get; set; } = true;
 
 		// サマリー
 		public int ResolvedCount { get; private set; }

--- a/Editor/Scripts/PBRemap/Editor/PBRemapSceneRenderer.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapSceneRenderer.cs
@@ -55,8 +55,10 @@ namespace colloid.PBReplacer
 
 			foreach (var visual in state.VisualMappings)
 			{
-				if (state.ShowUnresolvedOnly && visual.Resolved)
-					continue;
+				// 3状態フィルター
+				if (visual.Resolved && !state.ShowResolved) continue;
+				if (!visual.Resolved && visual.AutoCreatable && !state.ShowAutoCreatable) continue;
+				if (!visual.Resolved && !visual.AutoCreatable && !state.ShowUnresolved) continue;
 
 				DrawBoneMapping(visual, state, sceneView);
 			}

--- a/Editor/Scripts/PBRemap/NDMF/PBRemapNDMFPass.cs
+++ b/Editor/Scripts/PBRemap/NDMF/PBRemapNDMFPass.cs
@@ -41,6 +41,9 @@ namespace colloid.PBReplacer
                         Debug.Log(
                             $"[PBReplacer PBRemap] {definition.gameObject.name}: " +
                             $"{success.RemappedReferenceCount} references remapped" +
+                            (success.AutoCreatedObjectCount > 0
+                                ? $", {success.AutoCreatedObjectCount} objects auto-created"
+                                : "") +
                             (success.UnresolvedReferenceCount > 0
                                 ? $", {success.UnresolvedReferenceCount} unresolved"
                                 : ""));

--- a/Runtime/Scripts/BoneMapping.cs
+++ b/Runtime/Scripts/BoneMapping.cs
@@ -20,5 +20,11 @@ namespace colloid.PBReplacer
 
         /// <summary>解決に失敗した場合のエラーメッセージ</summary>
         public string errorMessage;
+
+        /// <summary>親ボーンが解決済みで、子オブジェクトの自動作成が可能か</summary>
+        public bool autoCreatable;
+
+        /// <summary>自動作成時のデスティネーション側パス（親のdestPath + "/" + ソースのボーン名）</summary>
+        public string autoCreateDestPath;
     }
 }

--- a/Runtime/Scripts/SerializedBoneReference.cs
+++ b/Runtime/Scripts/SerializedBoneReference.cs
@@ -30,5 +30,8 @@ namespace colloid.PBReplacer
 
         /// <summary>Humanoid祖先からの相対パス（例: "Hair_Root/Hair_01"）</summary>
         public string pathFromHumanoidAncestor;
+
+        /// <summary>このボーンまたは子孫がSkinnedMeshRendererにバインドされているか（スケルトンの一部か）</summary>
+        public bool isSkeletonBone;
     }
 }


### PR DESCRIPTION
## Summary
This PR adds automatic creation of helper objects (non-skeleton bones) during the PBRemap process when their parent bones are successfully resolved. This allows child objects to be automatically instantiated on the destination avatar rather than remaining unresolved.

## Key Changes

### Core Remapping Logic
- Added `AutoCreatedObjectCount` property to `RemapResult` to track auto-created objects
- Implemented `AutoCreateHelperObjects()` method in live mode that:
  - Collects unresolved external Transform references
  - Filters out skeleton bones (those bound to SkinnedMeshRenderers)
  - Creates missing child objects under resolved parent bones
  - Registers created objects with Undo system
- Implemented `TryAutoCreateFromSerialized()` for prefab mode to auto-create from serialized bone references
- Added `ResolveParentForAutoCreate()` helper to resolve parent paths using direct matching, remap rules, and name matching

### Bone Classification
- Added `CollectSkinnedBones()` to identify all bones bound to SkinnedMeshRenderers
- Added `IsSkeletonBone()` to determine if a bone is part of the skeleton (not a helper object)
- These methods prevent accidental auto-creation of actual skeleton bones

### Preview & Visualization
- Added `AutoCreatableBones` tracking to `PBRemapPreviewData`
- Updated preview generation to identify bones that can be auto-created (unresolved but with resolved parents)
- Enhanced `BoneMapping` with `autoCreatable` and `autoCreateDestPath` properties
- Implemented 3-state filtering system (Resolved / Auto-Creatable / Unresolved) in:
  - Scene overlay with visual chips and filter toggles
  - Preview window with synchronized filter state
  - Scene renderer with distinct visual styling for auto-creatable bones

### Visual Feedback
- Added yellow/gold color scheme for auto-creatable bones in scene visualization
- Implemented `DrawAutoCreateBezier()` to show connections from source to parent destination
- Updated UI to display auto-creatable count separately from unresolved
- Added "(作成予定)" labels to indicate auto-creation intent
- Synchronized filter state between Scene Overlay and Preview Window

### UI/UX Improvements
- Replaced single "Show Unresolved Only" toggle with 3-state filter chips
- Updated resolution summary displays to show resolved/auto-creatable/unresolved counts
- Enhanced USS styling for filter bars and summary chips across inspector and overlays
- Added visual distinction between different bone resolution states

## Implementation Details
- Auto-creation respects parent-child hierarchy by processing bones in depth order
- Existing objects with matching names are reused rather than duplicated
- Both live mode (direct Transform references) and prefab mode (serialized references) are supported
- Filter state is shared between Scene Overlay and Preview Window for consistent UX
- All created objects are registered with Undo for proper undo/redo support

https://claude.ai/code/session_01KzzJwNosq7TjrgevCyEnbr