### PR TITLE
Refactor filter state management to use events instead of polling

### DIFF
--- a/Editor/Scripts/PBRemap/Editor/PBRemapScenePreviewState.cs
+++ b/Editor/Scripts/PBRemap/Editor/PBRemapScenePreviewState.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
@@ -14,6 +15,12 @@ namespace colloid.PBReplacer
 		public static PBRemapScenePreviewState Instance =>
 			_instance ??= new PBRemapScenePreviewState();
 
+		/// <summary>フィルター状態が変更された時に発火するイベント</summary>
+		public event Action FilterStateChanged;
+
+		/// <summary>プレビューデータが変更された時に発火するイベント（Activate/Deactivate）</summary>
+		public event Action PreviewDataChanged;
+
 		public bool IsActive { get; private set; }
 
 		public PBRemapPreviewData PreviewData { get; private set; }
@@ -26,9 +33,28 @@ namespace colloid.PBReplacer
 		// 表示設定
 		public bool ShowConnectionLines { get; set; } = true;
 		public bool ShowBoneLabels { get; set; } = false;
-		public bool ShowResolved { get; set; } = true;
-		public bool ShowAutoCreatable { get; set; } = true;
-		public bool ShowUnresolved { get; set; } = true;
+
+		private bool _showResolved = true;
+		private bool _showAutoCreatable = true;
+		private bool _showUnresolved = true;
+
+		public bool ShowResolved
+		{
+			get => _showResolved;
+			set { if (_showResolved != value) { _showResolved = value; FilterStateChanged?.Invoke(); } }
+		}
+
+		public bool ShowAutoCreatable
+		{
+			get => _showAutoCreatable;
+			set { if (_showAutoCreatable != value) { _showAutoCreatable = value; FilterStateChanged?.Invoke(); } }
+		}
+
+		public bool ShowUnresolved
+		{
+			get => _showUnresolved;
+			set { if (_showUnresolved != value) { _showUnresolved = value; FilterStateChanged?.Invoke(); } }
+		}
 
 		// サマリー
 		public int ResolvedCount { get; private set; }
@@ -45,6 +71,7 @@ namespace colloid.PBReplacer
 			Detection = detection;
 			IsActive = true;
 			RebuildVisualCache();
+			PreviewDataChanged?.Invoke();
 		}
 
 		/// <summary>
@@ -60,6 +87,7 @@ namespace colloid.PBReplacer
 			AutoCreatableCount = 0;
 			TotalCount = 0;
 			SceneView.RepaintAll();
+			PreviewDataChanged?.Invoke();
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary
Refactored the filter state management system to use event-driven updates instead of periodic polling. This improves performance and responsiveness by eliminating unnecessary scheduled checks and enabling immediate UI updates when filter states change.

## Key Changes

### StatusStateBase.cs
- Modified `Exit()` method to call `CancelTimeout()` to ensure proper cleanup
- Refactored timeout mechanism from `delayCall` (one-time) to `update` (continuous) subscription
- Replaced recursive `CheckTimeout()` method with a stored callback reference (`_timeoutCallback`)
- Added `CancelTimeout()` method to properly unsubscribe from `EditorApplication.update`
- Improved timeout logic to check if state is still active before invoking callback

### PBRemapScenePreviewState.cs
- Added `FilterStateChanged` and `PreviewDataChanged` events
- Converted filter properties (`ShowResolved`, `ShowAutoCreatable`, `ShowUnresolved`) to use backing fields with property setters that invoke `FilterStateChanged` event when values change
- Invoked `PreviewDataChanged` event in `Activate()` and `Deactivate()` methods

### PBRemapPreviewWindow.cs
- Removed filter state cache fields (`_cachedShowResolved`, `_cachedShowAutoCreatable`, `_cachedShowUnresolved`)
- Removed `CheckFilterSync()` polling method and `SyncFilterCache()` helper
- Replaced 200ms scheduled polling with event subscription to `FilterStateChanged`
- Added `OnFilterStateChanged()` callback that triggers `Rebuild()`
- Simplified filter toggle callbacks to only set the property value (event handling now triggers UI updates)
- Added proper event unsubscription in `OnDestroy()`

### PBRemapSceneOverlay.cs
- Replaced 500ms scheduled polling with event subscriptions to both `FilterStateChanged` and `PreviewDataChanged`
- Added `OnStateChanged()` callback that updates panel and repaints scene
- Simplified filter chip callbacks to only set the property value
- Removed scheduled `UpdatePanel()` execution
- Added proper event unsubscription in `OnWillBeDestroyed()`

## Benefits
- **Performance**: Eliminates continuous polling (200ms and 500ms intervals), reducing CPU overhead
- **Responsiveness**: UI updates immediately when state changes rather than waiting for next poll cycle
- **Maintainability**: Event-driven architecture is clearer and easier to reason about
- **Reliability**: Proper cleanup of event subscriptions prevents memory leaks

https://claude.ai/code/session_01LXPGAqw4PYeJEHocif8bT2