### PR TITLE
Release 3.0.0-beta.5

### DIFF
--- a/Editor/Scripts/PBRemap/Core/SourceDetector.cs
+++ b/Editor/Scripts/PBRemap/Core/SourceDetector.cs
@@ -177,17 +177,25 @@ namespace colloid.PBReplacer
         /// 親階層を辿ってアバタールートとなるGameObjectを探す。
         /// PBRemap自身のGameObjectは除外する。
         /// 検出優先順位:
-        /// 1. VRC_AvatarDescriptor（VRCアバター）
-        /// 2. Animator（FBXインポート等）
-        /// 3. ModularAvatarコンポーネント（MA衣装）
-        /// 4. PrefabInstanceRoot（Prefabインスタンス）
+        /// 1. PBRemap自身が属するPrefabルート（Prefab境界内に限定）
+        /// 2. VRC_AvatarDescriptor（VRCアバター）
+        /// 3. Animator（FBXインポート等）
+        /// 4. ModularAvatarコンポーネント（MA衣装）
         /// 5. ルートGameObject（最終手段）
         /// </summary>
         private static GameObject FindAvatarRootInParent(Transform current)
         {
+            // 第1段階: PBRemap自身が属するPrefabルートを確認
+            // AD > MA.prefab > PBRemap の構造でMAが正しくDestinationになるよう、
+            // 祖先を全辿りする前にPrefab境界で先に確定させる
+            var ownPrefabRoot = PrefabUtility.GetNearestPrefabInstanceRoot(current.gameObject);
+            if (ownPrefabRoot != null)
+                return ownPrefabRoot;
+
+            // Prefabに属さない場合（シーン直置き等）は親階層を辿る
             Transform parent = current.parent;
 
-            // 第1段階: VRC_AvatarDescriptorを探す
+            // 第2段階: VRC_AvatarDescriptorを探す
             Transform scan = parent;
             while (scan != null)
             {
@@ -196,7 +204,7 @@ namespace colloid.PBReplacer
                 scan = scan.parent;
             }
 
-            // 第2段階: Animatorを探す（最も上位にあるAnimatorを返す）
+            // 第3段階: Animatorを探す（最も上位にあるAnimatorを返す）
             scan = parent;
             GameObject animatorRoot = null;
             while (scan != null)
@@ -208,7 +216,7 @@ namespace colloid.PBReplacer
             if (animatorRoot != null)
                 return animatorRoot;
 
-            // 第3段階: ModularAvatarコンポーネントを探す
+            // 第4段階: ModularAvatarコンポーネントを探す
             #if MODULAR_AVATAR
             scan = parent;
             while (scan != null)
@@ -218,14 +226,6 @@ namespace colloid.PBReplacer
                 scan = scan.parent;
             }
             #endif
-
-            // 第4段階: Prefabインスタンスルートを探す
-            if (parent != null)
-            {
-                var prefabRoot = PrefabUtility.GetNearestPrefabInstanceRoot(parent);
-                if (prefabRoot != null)
-                    return prefabRoot;
-            }
 
             // 第5段階: ルートGameObject
             if (parent != null)

--- a/Editor/Scripts/PBRemap/Core/SourceDetector.cs
+++ b/Editor/Scripts/PBRemap/Core/SourceDetector.cs
@@ -178,9 +178,9 @@ namespace colloid.PBReplacer
         /// PBRemap自身のGameObjectは除外する。
         /// 検出優先順位:
         /// 1. PBRemap自身が属するPrefabルート（Prefab境界内に限定）
-        /// 2. VRC_AvatarDescriptor（VRCアバター）
-        /// 3. Animator（FBXインポート等）
-        /// 4. ModularAvatarコンポーネント（MA衣装）
+        /// 2. ModularAvatarMergeArmature（VRC依存、最も具体的）
+        /// 3. VRC_AvatarDescriptor（アバター依存）
+        /// 4. Animator（最も汎用的）
         /// 5. ルートGameObject（最終手段）
         /// </summary>
         private static GameObject FindAvatarRootInParent(Transform current)
@@ -195,8 +195,23 @@ namespace colloid.PBReplacer
             // Prefabに属さない場合（シーン直置き等）は親階層を辿る
             Transform parent = current.parent;
 
-            // 第2段階: VRC_AvatarDescriptorを探す
+            // 第2段階: ModularAvatarMergeArmatureを探す（VRC依存の最具体的コンポーネント）
+            #if MODULAR_AVATAR
             Transform scan = parent;
+            while (scan != null)
+            {
+                if (scan.GetComponent<ModularAvatarMergeArmature>() != null)
+                    return scan.gameObject;
+                scan = scan.parent;
+            }
+            #endif
+
+            // 第3段階: VRC_AvatarDescriptorを探す
+            #if MODULAR_AVATAR
+            scan = parent;
+            #else
+            Transform scan = parent;
+            #endif
             while (scan != null)
             {
                 if (scan.GetComponent<VRC_AvatarDescriptor>() != null)
@@ -204,7 +219,7 @@ namespace colloid.PBReplacer
                 scan = scan.parent;
             }
 
-            // 第3段階: Animatorを探す（最も上位にあるAnimatorを返す）
+            // 第4段階: Animatorを探す（最も上位にあるAnimatorを返す）
             scan = parent;
             GameObject animatorRoot = null;
             while (scan != null)
@@ -215,17 +230,6 @@ namespace colloid.PBReplacer
             }
             if (animatorRoot != null)
                 return animatorRoot;
-
-            // 第4段階: ModularAvatarコンポーネントを探す
-            #if MODULAR_AVATAR
-            scan = parent;
-            while (scan != null)
-            {
-                if (scan.GetComponent<ModularAvatarMergeArmature>() != null)
-                    return scan.gameObject;
-                scan = scan.parent;
-            }
-            #endif
 
             // 第5段階: ルートGameObject
             if (parent != null)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.colloid.pbreplacer",
   "displayName": "PBReplacer",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "PhysBone\u3068PhysBoneCollider\u3092\u6574\u7406\u3059\u308bUnity\u62e1\u5f35\u3002\n1\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\uff1d1\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306b\u7f6e\u63db\u3002",
   "author": {
     "name": "\uff7a\uff9b\uff72\uff84\uff9e"


### PR DESCRIPTION
## 概要
PBRemap の Destination 自動検出に関する不具合を修正した **3.0.0-beta.5** をパブリックベータテスト向けにリリースします。
このPRを main にマージすると、GitHub Actions により自動的にタグ作成・Release 作成・VPM リスト更新が実行されます。

## 変更点

### 🐛 Fix: Destination 検出を Prefab 境界内に限定 (9f5832f)
`AD.prefab > MA.prefab > PBRemap` のネスト Prefab 構造で、外側の VRC_AvatarDescriptor を持つ AD Prefab ではなく、PBRemap が属する MA Prefab（衣装）が正しく Destination として返るよう修正。

`GetNearestPrefabInstanceRoot` で Prefab ルートを先に確定させ、Prefab に属さない場合は従来の親辿りロジックへフォールバック。

### 🐛 Fix: フォールバック検出順を依存順に修正 (1d9a78d)
`VRC_AvatarDescriptor → Animator → ModularAvatarMergeArmature` の順だと上位の汎用コンポーネントに誤検出されるため、`ModularAvatarMergeArmature → VRC_AvatarDescriptor → Animator` の順に変更。

## テスト観点（パブリックテスト協力者向け）

- [ ] **ネスト Prefab**: 素体 Prefab に衣装 Prefab を入れて衣装側に PBRemap を置き、Destination が衣装 Prefab ルートになること
- [ ] **シーン直置き**: Prefab に属さない状態で Destination が従来通り検出されること
- [ ] **MA 利用時**: ModularAvatarMergeArmature を持つオブジェクトが優先して検出されること
- [ ] **既存機能の回帰**: 通常の PhysBone / Constraint / Contact 再配置に影響がないこと

## リリース自動化フロー
main へのマージ後、以下が自動実行されます:
1. `create-tag.yml` — `package.json` の version を検知し `3.0.0-beta.5` タグを作成
2. `release.yml` — `.zip` / `.unitypackage` をビルドし GitHub Releases に公開
3. `build-listing.yml` — VPM パッケージリストを更新

## 変更ファイル
- `Editor/Scripts/PBRemap/Core/SourceDetector.cs` （+29 / -25）
- `package.json` （3.0.0-beta.4 → 3.0.0-beta.5）

🤖 Generated with [Claude Code](https://claude.com/claude-code)