### PR TITLE
fix: AvatarDynamics サブツリー二重スキャンによるリスト重複表示を修正

### DIFF
--- a/ChangeLog-Beta.txt
+++ b/ChangeLog-Beta.txt
@@ -8,3 +8,4 @@ PBRemap: ModularAvatar検出の探索範囲を祖先の子孫全体に拡張
 PBRemap: アバター検出方法をDetectionResultとして保持し、Inspectorバッジで検出手段を明示
 CleanupUnusedFoldersをICommandに切り出し、全タブで確実に実行されるよう修正
 リリース作成後にBuild Repo Listingを自動起動するようにワークフローを修正
+FindComponent.AllChilds時にAvatarDynamics配下のコンポーネントが二重検出されリストに重複表示される問題を修正（Distinctによるフェイルセーフも追加）

--- a/Editor/Scripts/Managers/Base/ComponentManagerBase.cs
+++ b/Editor/Scripts/Managers/Base/ComponentManagerBase.cs
@@ -122,48 +122,75 @@ namespace colloid.PBReplacer
 				InvokeChanged();
 				return;
 			}
-			
+
 			IEnumerable<T> targetComponents = _settings.FindComponent switch
 			{
 				FindComponent.InArmature => CurrentAvatar.Armature.GetComponentsInChildren<T>(true),
-				
+
 				FindComponent.InPrefab => PrefabUtility.IsPartOfAnyPrefab(CurrentAvatar.AvatarObject)
 				? CurrentAvatar.AvatarObject.GetComponentsInChildren<T>(true)
 				.Where(c => PrefabUtility.GetNearestPrefabInstanceRoot(c) == PrefabUtility.GetNearestPrefabInstanceRoot(CurrentAvatar.AvatarObject))
 				: CurrentAvatar.Armature.GetComponentsInChildren<T>(true),
-				
+
 				FindComponent.AllChilds => CurrentAvatar.AvatarObject.GetComponentsInChildren<T>(true),
-				
+
 				_ => null
 			};
-			
-			targetComponents ??= CurrentAvatar.Armature.GetComponentsInChildren<T>(true); 
 
-			_components.AddRange(targetComponents);
-            
-			_components.AddRange(GetAvatarDynamicsComponent<T>());
-			
+			targetComponents ??= CurrentAvatar.Armature.GetComponentsInChildren<T>(true);
+
+			// 根本対応: AvatarDynamics サブツリー配下は別途合流させるため、通常検索結果からは除外
+			var avatarDynamicsRoot = GetAvatarDynamicsRoot();
+			if (avatarDynamicsRoot != null)
+			{
+				targetComponents = targetComponents.Where(c => !IsUnderAvatarDynamics(c, avatarDynamicsRoot));
+			}
+
+			// フェイルセーフ: Concat で合流した後に Distinct で重複排除（参照等価）
+			var combined = targetComponents
+				.Concat(GetAvatarDynamicsComponent<T>())
+				.Where(c => c != null)
+				.Distinct();
+
+			_components.AddRange(combined);
+
 			InvokeChanged();
 		}
-		
+
 		// 抽象メソッド
 		public abstract bool ProcessComponents();
-    
+
 		// ヘルパーメソッド
 		public List<TComponent> GetAvatarDynamicsComponent<TComponent>() where TComponent : Component
 		{
 			var result = new List<TComponent>();
-			
+
 			// AvatarDynamics内にすでに移動されているコンポーネントを検索（再実行時用）
-			if (CurrentAvatar?.AvatarObject == null) return result;
-    
-			var avatarDynamicsTransform = CurrentAvatar.AvatarObject.transform.Find("AvatarDynamics");
+			var avatarDynamicsTransform = GetAvatarDynamicsRoot();
 			if (avatarDynamicsTransform == null) return result;
-    
+
 			// 該当するコンポーネントをすべて収集
 			result.AddRange(avatarDynamicsTransform.GetComponentsInChildren<TComponent>(true));
 
 			return result;
+		}
+
+		/// <summary>
+		/// 設定で指定された名称の AvatarDynamics ルート Transform を取得する。
+		/// ルート名は PBReplacerSettings.RootObjectName（将来ユーザー設定化予定）から取る。
+		/// </summary>
+		protected Transform GetAvatarDynamicsRoot()
+		{
+			if (CurrentAvatar?.AvatarObject == null) return null;
+			var rootName = _settings?.RootObjectName;
+			if (string.IsNullOrEmpty(rootName)) return null;
+			return CurrentAvatar.AvatarObject.transform.Find(rootName);
+		}
+
+		private static bool IsUnderAvatarDynamics(Component c, Transform avatarDynamicsRoot)
+		{
+			if (avatarDynamicsRoot == null || c == null) return false;
+			return c.transform.IsChildOf(avatarDynamicsRoot);
 		}
 		
 		protected virtual void NotifyComponentsChanged()


### PR DESCRIPTION
## Summary

- `FindComponent.AllChilds` 設定時に `LoadComponents()` が AvatarObject 全体を走査したうえで `GetAvatarDynamicsComponent<T>()` の結果を追加連結しており、移植済みコンポーネントが UI リストに重複表示されていた問題を修正
- 根本対応として、通常検索結果から AvatarDynamics サブツリー配下を `Transform.IsChildOf` で除外してから合流させる
- フェイルセーフとして `Concat` 後に `Distinct()` で参照等価による重複排除を追加
- ルート名のハードコード `"AvatarDynamics"` を排除し、既存の `PBReplacerSettings.RootObjectName`（将来ユーザー設定化予定）参照に統一。同ファイル内の `GetAvatarDynamicsComponent<T>()` 内のハードコードもまとめて差し替え

## 変更ファイル

- `Editor/Scripts/Managers/Base/ComponentManagerBase.cs`
- `ChangeLog-Beta.txt`

スコープ外として残るハードコード `"AvatarDynamics"` は `DataManagerHelper.cs` と `AvatarData.cs` に存在。本 PR では触らず、別タスクに分離（リグレッション面を切り分けるため）。

## Test plan

- [x] `FindComponent = AllChilds` 設定で、AvatarDynamics 配下に移植済みコンポーネントが存在するアバターを再ロード → PhysBone / PhysBoneCollider / Constraint / Contact の各タブのリストに重複が出ないこと
- [ ] `FindComponent = InArmature` / `InPrefab` でもリグレッションなく想定通り表示されること
- [ ] `AvatarDynamics` オブジェクトが存在しない新規アバターで、全コンポーネントが 1 件ずつ表示されること
- [x] Undo (Ctrl+Z) で処理前の状態に戻せること

🤖 Generated with [Claude Code](https://claude.com/claude-code)